### PR TITLE
added support for the artifact 'classifier'

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ grunt.initConfig({
 		  artifactId: "grunt-nexus-deployer",
 		  version: "1.0",
 		  packaging: 'zip',
+                  classifier: 'dev',
 		  auth: {
 			username:'admin',
 			password:'admin123'
@@ -68,6 +69,12 @@ Type: `String`
 Default value: `''`
 
 Type of artifact. eg zip, jar, pom, war etc.
+
+#### options.classifier
+Type: `String`
+Defaut value: `''`
+
+An optional classifier that can further distinguish between artifacts of the same group, id and version. eg dev, prod etc. (i.e. artifact-1.0-dev.zip, artifact-1.0-prod.zip)
 
 #### options.version
 Type: `String`

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -106,6 +106,9 @@ var createAndUploadArtifacts = function (options, done) {
     uploads[pomDir + "/pom.xml.md5"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.pom.md5';
 
 
+    if(options.classifier) {
+        remoteArtifactName = remoteArtifactName + "-" + options.classifier;
+    }
     uploads[options.artifact] = groupArtifactVersionPath + '/' + remoteArtifactName + '.' + options.packaging;
     uploads[pomDir + "/artifact." + options.packaging + ".sha1"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.' + options.packaging + '.sha1';
     uploads[pomDir + "/artifact." + options.packaging + ".md5"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.' + options.packaging + '.md5';


### PR DESCRIPTION
Hi,
I had to push some artifacts that also had a 'classifier' in the artifact name. I tried using your module, I noticed it does not support classifiers and I want to help so I wrote this little patch.

Please review this change and merge it if you think it is OK.

Thank you,
Ovidiu
