### PR TITLE
npm runtime dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,16 +26,18 @@
     "scripts": {
         "test": "grunt test"
     },
+    "dependencies": {
+        "dateformat":"1.0.7-1.2.3",
+        "async": "0.2.10",
+        "ejs": "~0.8.5"
+    },
     "devDependencies": {
         "grunt-contrib-jshint": "~0.8.0",
         "grunt-contrib-clean": "~0.5.0",
         "grunt": "~0.4.2",
         "grunt-mocha-test": "~0.8.2",
-        "dateformat":"1.0.7-1.2.3",
-        "async": "0.2.10",
         "should":"~3.1.2",
-        "grunt-env":"*",
-        "ejs": "~0.8.5"
+        "grunt-env":"*"
     },
     "peerDependencies": {
         "grunt": "~0.4.2"


### PR DESCRIPTION
After installing _grunt-nexus-deployer_ package from _npm_, runtime dependencies (_ejs_, _async_ and _dateformat_) aren't available, because they are listed in devDependencies.
