### PR TITLE
skipping curl ssl validation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,7 +51,8 @@ module.exports = function (grunt) {
                     artifact: 'test/fixtures/example.zip',
                     noproxy: 'localhost',
                     cwd: '',
-                    quiet: false
+                    quiet: false,
+                    insecure: true
                 }
             },
             release: {

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -59,14 +59,30 @@ var createAndUploadArtifacts = function (options, done) {
             if (!options.quiet) {
                 log.write('Uploading to ' + targetUri + "\n\n");
             }
-            var auth = "";
+
+            var curlOptions = [
+                '--silent',
+                '--output', '/dev/stderr',
+                '--write-out', '%{http_code}',
+                '--upload-file', fileLocation,
+                '--noproxy', options.noproxy ? options.noproxy : '127.0.0.1'
+            ];
+
             if (options.auth) {
-                auth = "-u " + options.auth.username + ":" + options.auth.password;
+                curlOptions.push('-u');
+                curlOptions.push(options.auth.username + ":" + options.auth.password);
             }
-            var noproxy = '--noproxy ' + (options.noproxy ? options.noproxy : '127.0.0.1');
+
+            if (options.insecure) {
+                curlOptions.push('--insecure');
+            }
+
             var execOptions = {};
             options.cwd && (execOptions.cwd = options.cwd);
-            var childProcess = exec('curl --silent --output /dev/stderr --write-out %{http_code} ' + auth + ' ' + noproxy + ' --upload-file ' + fileLocation + ' ' + targetUri, execOptions, function () {
+
+            var curlCmd = ['curl', curlOptions.join(' '), targetUri].join(' ');
+
+            var childProcess = exec(curlCmd, execOptions, function () {
             });
             childProcess.stdout.on('data', function (data) {
                 status = data;

--- a/test/nexus_deployer_test.js
+++ b/test/nexus_deployer_test.js
@@ -52,6 +52,21 @@ describe('Nexus Deployer', function () {
             }).length.should.equal(3);
         });
 
+        it('ssl certificate errors can be skipped', function () {
+            snapshotHistory.forEach(function (callParams) {
+                if (callParams) {
+                    callParams.should.match(/--insecure/);
+                }
+            });
+        });
+
+        it('ssl certificate errors are not skipped by default', function () {
+            releaseHistory.forEach(function (callParams) {
+                if (callParams) {
+                    callParams.should.not.match(/--insecure/);
+                }
+            });
+        });
 
     });
 


### PR DESCRIPTION
Change that allows skipping certificate check during upload to a nexus. 

Sometimes (especially in internal corporate networks) websites identity cannot be determined (eg. its server uses domain name only reachable in local network) regardless actual certificate validity.
