### PR TITLE
Add possibility to configure username and password on command line. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,14 @@ grunt.initConfig({
 });
 ```
 
-To run
+To run 
 ```
 grunt nexusDeployer
+```
+
+To run with authentication defined on command line
+```
+grunt nexusDeployer --username=<<username>> --password=<<password>>
 ```
 
 ## Release History

--- a/tasks/nexus_deployer.js
+++ b/tasks/nexus_deployer.js
@@ -18,6 +18,24 @@ module.exports = function (grunt) {
             dryRun: false,
             cwd: ''
         });
+
+        /*
+         * If a username or password is passed on the command line, the configuration in the Gruntfile.js is overridden.
+         *
+         * Example: grunt nexusDeployer --username=user --password=password
+         *
+         * @author Geroen Joris 
+         */
+        var passedUsername = grunt.option('username');
+        var passedPassword = grunt.option('password');
+        if (passedUsername || passedPassword) {
+            grunt.verbose.writeln("Found username and password on the command line. Overriding the configured authentication, if any.");
+            options.auth = {
+                username: passedUsername,
+                password: passedPassword
+            }
+        }
+
         var done = this.async();
         deploy(options, done);
     });


### PR DESCRIPTION
This addition will allow the user of the plugin to define their username and password for Nexus on the command line. This way, you don't have to put your username and password plain text in the configuration. 