### PR TITLE
#9 Documented option to accept Self-Signed Certs when connecting over https

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ Default value: `''`
 
 Username to be used for authentication against nexus server
 
+#### options.insecure
+Type: `boolean`
+Default value: `false`
+
+Accept Self-Signed certificates when connecting over https.
+
 #### options.url
 Type: `String`
 Default value: `''`


### PR DESCRIPTION
The option to accept self-signed certs was implemented but never documented ie

    options.insecure = true