### PR TITLE
Fix #11. Use "close" instead of "exit".

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-nexus-deployer",
     "description": "Deploy artifacts with classifiers to release/snapshot maven repository.",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "homepage": "https://github.com/skhatri/grunt-nexus-deployer",
     "author": {
         "name": "Suresh Khatri",
@@ -27,9 +27,9 @@
         "test": "grunt test"
     },
     "dependencies": {
-        "dateformat":"1.0.7-1.2.3",
-        "async": "0.2.10",
-        "ejs": "~0.8.5"
+        "dateformat":"1.0.11",
+        "async": "0.9.0",
+        "ejs": "~2.3.1"
     },
     "devDependencies": {
         "grunt-contrib-jshint": "~0.8.0",

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -87,7 +87,7 @@ var createAndUploadArtifacts = function (options, done) {
             childProcess.stdout.on('data', function (data) {
                 status = data;
             });
-            childProcess.on('exit', function (code) {
+            childProcess.on('close', function (code) {
                 if (code !== 0 || (status !== "200" && status !== "201")) {
                     cb("Status code " + status + " for " + targetUri, null);
                 } else {


### PR DESCRIPTION
Exit event was returning before stdin stream be closed. This made an intermittent behaviour, failing to write the variable "status" sometimes.  

close event - https://nodejs.org/api/child_process.html#child_process_event_exit
exit event - https://nodejs.org/api/child_process.html#child_process_event_close