### PR TITLE
Support for SNAPSHOT, externally supplied build time and control over meta-data upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 npm-debug.log
 tmp
+*~
 .idea
 test/pom
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,6 +41,7 @@ module.exports = function (grunt) {
                     groupId: "grunt-nexus-deployer",
                     artifactId: "grunt-nexus-deployer",
                     version: "1.2-SNAPSHOT",
+                    buildNumber: "14",
                     packaging: 'zip',
                     auth: {
                         username: auth.username,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "repository": {
         "type": "git",
-        "url": "git@github.com:skhatri/grunt-nexus-deployer.git"
+        "url": "git@github.com:SpritzInc/grunt-nexus-deployer.git"
     },
     "bugs": {
         "url": "https://github.com/skhatri/grunt-nexus-deployer/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "grunt-nexus-deployer",
     "description": "Deploy artifacts with classifiers to release/snapshot maven repository.",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "homepage": "https://github.com/skhatri/grunt-nexus-deployer",
     "author": {
         "name": "Suresh Khatri",

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -118,17 +118,23 @@ var createAndUploadArtifacts = function (options, done) {
 
     var remoteArtifactName = options.artifactId + '-' + options.version;
     
+    // Strip off the "-SNAPSHOT" on the end of the version to get the M2 base time-stamped name
+    if (remoteArtifactName.length >= "-SNAPSHOT".length && remoteArtifactName.substring(remoteArtifactName.length - "-SNAPSHOT".length) === "-SNAPSHOT") {
+        remoteArtifactName = remoteArtifactName.substring(0, remoteArtifactName.length - "-SNAPSHOT".length);
+    }
+    
     if (snapshot) {
-    	remoteArtifactName += "-" + options.timestamp + "-" + options.buildNumber;
+        remoteArtifactName += "-" + options.timestamp + "-" + options.buildNumber;
     }
     
     uploads[pomDir + "/pom.xml"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.pom';
     uploads[pomDir + "/pom.xml.sha1"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.pom.sha1';
     uploads[pomDir + "/pom.xml.md5"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.pom.md5';
 
-    if(options.classifier) {
+    if (options.classifier) {
         remoteArtifactName = remoteArtifactName + "-" + options.classifier;
     }
+    
     uploads[options.artifact] = groupArtifactVersionPath + '/' + remoteArtifactName + '.' + options.packaging;
     uploads[pomDir + "/artifact." + options.packaging + ".sha1"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.' + options.packaging + '.sha1';
     uploads[pomDir + "/artifact." + options.packaging + ".md5"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.' + options.packaging + '.md5';

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -161,8 +161,16 @@ module.exports = function (options, cb) {
         throw {name: "IllegalArgumentException", message: "upload artifact options required."};
     }
     exec = process.env.MOCK_NEXUS ? require('./mockexec') : require('child_process').exec;
-    var now = new Date();
-    options.lastUpdated = dateformat(now, "yyyymmddHHMMss");
-    options.timestamp = dateformat(now, "yyyymmdd.HHMMss");
+    
+    var timestamp;
+    
+    if (typeof(options.buildTime) === 'string') {
+    	timestamp = Date.parse(options.buildTime);
+    } else {
+    	timestamp = new Date();
+    }
+    
+    options.lastUpdated = dateformat(timestamp, "yyyymmddHHMMss");
+    options.timestamp = dateformat(timestamp, "yyyymmdd.HHMMss");
     createAndUploadArtifacts(options, cb);
 };

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -42,6 +42,8 @@ var createAndUploadArtifacts = function (options, done) {
     var snapshot = SNAPSHOT_VER.test(options.version);
 
     options.parallel = options.parallel === undefined ? false : options.parallel;
+    options.uploadMetadata = options.uploadMetadata === undefined ? true : options.uploadMetadata;
+
     if (!file.exists(pomDir)) {
         file.mkdir(pomDir);
     }
@@ -103,17 +105,18 @@ var createAndUploadArtifacts = function (options, done) {
 
     var groupIdAsPath = options.groupId.replace(/\./g, "/");
     var groupArtifactPath = groupIdAsPath + '/' + options.artifactId;
-
-    uploads[pomDir + "/outer.xml"] = groupArtifactPath + '/' + 'maven-metadata.xml';
-    uploads[pomDir + "/outer.xml.sha1"] = groupArtifactPath + '/' + 'maven-metadata.xml.sha1';
-    uploads[pomDir + "/outer.xml.md5"] = groupArtifactPath + '/' + 'maven-metadata.xml.md5';
-
     var groupArtifactVersionPath = groupArtifactPath + '/' + options.version;
-    
-    if (snapshot) {
-        uploads[pomDir + "/inner.xml"] = groupArtifactVersionPath + '/' + 'maven-metadata.xml';
-        uploads[pomDir + "/inner.xml.sha1"] = groupArtifactVersionPath + '/' + 'maven-metadata.xml.sha1';
-        uploads[pomDir + "/inner.xml.md5"] = groupArtifactVersionPath + '/' + 'maven-metadata.xml.md5';
+
+    if (options.uploadMetadata) {
+        uploads[pomDir + "/outer.xml"] = groupArtifactPath + '/' + 'maven-metadata.xml';
+        uploads[pomDir + "/outer.xml.sha1"] = groupArtifactPath + '/' + 'maven-metadata.xml.sha1';
+        uploads[pomDir + "/outer.xml.md5"] = groupArtifactPath + '/' + 'maven-metadata.xml.md5';
+
+        if (snapshot) {
+            uploads[pomDir + "/inner.xml"] = groupArtifactVersionPath + '/' + 'maven-metadata.xml';
+            uploads[pomDir + "/inner.xml.sha1"] = groupArtifactVersionPath + '/' + 'maven-metadata.xml.sha1';
+            uploads[pomDir + "/inner.xml.md5"] = groupArtifactVersionPath + '/' + 'maven-metadata.xml.md5';
+        }
     }
 
     var remoteArtifactName = options.artifactId + '-' + options.version;
@@ -126,10 +129,12 @@ var createAndUploadArtifacts = function (options, done) {
     if (snapshot) {
         remoteArtifactName += "-" + options.timestamp + "-" + options.buildNumber;
     }
-    
-    uploads[pomDir + "/pom.xml"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.pom';
-    uploads[pomDir + "/pom.xml.sha1"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.pom.sha1';
-    uploads[pomDir + "/pom.xml.md5"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.pom.md5';
+
+    if (options.uploadMetadata) {
+        uploads[pomDir + "/pom.xml"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.pom';
+        uploads[pomDir + "/pom.xml.sha1"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.pom.sha1';
+        uploads[pomDir + "/pom.xml.md5"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.pom.md5';
+    }
 
     if (options.classifier) {
         remoteArtifactName = remoteArtifactName + "-" + options.classifier;

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -14,9 +14,9 @@ ejs.close = "}}";
 
 var cwd = __dirname;
 
-var createFile = function (template, options) {
-    var outerMetadata = file.read(cwd + '/../template/' + template);
-    var metadata = ejs.render(outerMetadata, options);
+var createFile = function (templateName, options) {
+    var template = file.read(cwd + '/../template/' + templateName);
+    var metadata = ejs.render(template, options);
     return metadata;
 };
 
@@ -37,16 +37,17 @@ var save = function (fileContent, pomDir, fileName) {
 };
 
 var createAndUploadArtifacts = function (options, done) {
+	var SNAPSHOT_VER = /.*SNAPSHOT$/i;
     var pomDir = options.pomDir || 'test/poms';
+    var snapshot = SNAPSHOT_VER.test(options.version);
 
     options.parallel = options.parallel === undefined ? false : options.parallel;
     if (!file.exists(pomDir)) {
         file.mkdir(pomDir);
     }
 
-
     save(createFile('project-metadata.xml', options), pomDir, 'outer.xml');
-    save(createFile('latest-metadata.xml', options), pomDir, 'inner.xml');
+    save(createFile(snapshot ? 'latest-snapshot-metadata.xml' : 'latest-metadata.xml', options), pomDir, 'inner.xml');
     save(createFile('pom.xml', options), pomDir, 'pom.xml');
 
     var artifactData = file.read(options.artifact, {encoding: 'binary'});
@@ -107,20 +108,23 @@ var createAndUploadArtifacts = function (options, done) {
     uploads[pomDir + "/outer.xml.sha1"] = groupArtifactPath + '/' + 'maven-metadata.xml.sha1';
     uploads[pomDir + "/outer.xml.md5"] = groupArtifactPath + '/' + 'maven-metadata.xml.md5';
 
-    var SNAPSHOT_VER = /.*SNAPSHOT$/i;
-
     var groupArtifactVersionPath = groupArtifactPath + '/' + options.version;
-    if (SNAPSHOT_VER.test(options.version)) {
+    
+    if (snapshot) {
         uploads[pomDir + "/inner.xml"] = groupArtifactVersionPath + '/' + 'maven-metadata.xml';
         uploads[pomDir + "/inner.xml.sha1"] = groupArtifactVersionPath + '/' + 'maven-metadata.xml.sha1';
         uploads[pomDir + "/inner.xml.md5"] = groupArtifactVersionPath + '/' + 'maven-metadata.xml.md5';
     }
 
     var remoteArtifactName = options.artifactId + '-' + options.version;
+    
+    if (snapshot) {
+    	remoteArtifactName += "-" + options.timestamp + "-" + options.buildNumber;
+    }
+    
     uploads[pomDir + "/pom.xml"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.pom';
     uploads[pomDir + "/pom.xml.sha1"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.pom.sha1';
     uploads[pomDir + "/pom.xml.md5"] = groupArtifactVersionPath + '/' + remoteArtifactName + '.pom.md5';
-
 
     if(options.classifier) {
         remoteArtifactName = remoteArtifactName + "-" + options.classifier;
@@ -157,6 +161,8 @@ module.exports = function (options, cb) {
         throw {name: "IllegalArgumentException", message: "upload artifact options required."};
     }
     exec = process.env.MOCK_NEXUS ? require('./mockexec') : require('child_process').exec;
-    options.lastUpdated = dateformat(new Date(), "yyyymmddHHMMss");
+    var now = new Date();
+    options.lastUpdated = dateformat(now, "yyyymmddHHMMss");
+    options.timestamp = dateformat(now, "yyyymmdd.HHMMss");
     createAndUploadArtifacts(options, cb);
 };

--- a/tasks/template/latest-snapshot-metadata.xml
+++ b/tasks/template/latest-snapshot-metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+    <groupId>{{=groupId}}</groupId>
+    <artifactId>{{=artifactId}}</artifactId>
+    <version>{{=version}}</version>
+    <versioning>
+        <snapshot>
+            <timestamp>{{=timestamp}}</timestamp>
+            <buildNumber>{{=buildNumber}}</buildNumber>
+        </snapshot>
+        <lastUpdated>{{=lastUpdated}}</lastUpdated>
+    </versioning>
+</metadata>


### PR DESCRIPTION
In an effort to better integrate builds with Jenkins and our Nexus repository, I added the following features:

- Support for an externally supplied build timestamp via `options.buildTime`.  This allows the same timestamp to be used for multiple artifact uploads.

- Generate an options.timestamp field which is formatted to yyyymmdd.HHMMss and is used for SNAPSHOT builds to identify each artifact in a unique way.  I'm not sure if this is the Maven 2 standard, but I based this on observing the behavior of the Maven Gradle plugin.

- Use a SNAPSHOT specific meta-data.xml template for SNAPSHOT builds.

- Add support for options.uploadMetadata (defaults to true) but allows multiple artifacts to be uploaded to a release repository, which doesn't normally allow overwriting.

These changes allowed me to publish both a debug and release build of my project, allowing me to choose which 'flavor' to apply to a server at deploy time via Salt Stack

Here is my example config:

## Some glue code to bridge from Jenkins:

```javascript
	grunt.registerTask('env', 'Sets up the grunt environment', function() {
		var buildNumber = grunt.option('buildNumber');
		var now = new Date();

		if (typeof(buildNumber) === 'undefined') {
			var timestamp = '';
			timestamp += now.getFullYear();

			if (now.getMonth() < 9) {
				timestamp += '0';
			}

			timestamp += (now.getMonth() + 1);

			if (now.getDate() < 10) {
				timestamp += '0';
			}

			timestamp += now.getDate();

			if (now.getHours() < 10) {
				timestamp += '0';
			}

			timestamp += now.getHours();

			if (now.getMinutes() < 10) {
				timestamp += '0';
			}

			timestamp += now.getMinutes();

			if (now.getSeconds() < 10) {
				timestamp += '0';
			}

			timestamp += now.getSeconds();

			buildNumber = 'L' + timestamp;
		}

		var release = grunt.option('release') === true ||  grunt.option('release') === 'true';
		var pkg = grunt.config('pkg');
		var mavenVersion = pkg.version;
		var publishUrl = release ?
			'https://nexus.example.org/content/repositories/releases' :
			'https://nexus.example.org/content/repositories/snapshots';

		if (!release) {
			mavenVersion += '-SNAPSHOT';
		}

		var versionInfo = 'v' + mavenVersion;

		if (!release) {
			versionInfo += '-' + buildNumber;
		}

		grunt.config('buildNumber', buildNumber);
		grunt.config('buildTime', now.toISOString());
		grunt.config('mavenVersion', mavenVersion);
		grunt.config('publishUrl', publishUrl);
		grunt.config('versionInfo', versionInfo);

		grunt.log.writeln('versionInfo: ' + versionInfo);
	});
```

## nexusDeployer config:

```javascript
nexusDeployer: {
	options: {
		auth: {
			username:'user',
			password:'password'
		},
		groupId: 'org.example.project',
		artifactId: '<%= pkg.name %>',
		version: '<%= mavenVersion %>',
		buildNumber: '<%= buildNumber %>',
		buildTime: '<%= buildTime %>',
		packaging: 'zip',
		pomDir: 'dist/pom',
		url: '<%= publishUrl %>'
	},
	debug: {
		options: {
			classifier: 'debug',
			uploadMetadata: true, // Since this is done first, upload the metadata here
			artifact: 'dist/<%=pkg.name%>-<%= pkg.version %>-debug.zip'
		}
	},
	release: {
		options: {
			classifier: '',
			uploadMetadata: false, // But skip it here, to prevent errors when publishing to a release repo
			artifact: 'dist/<%=pkg.name%>-<%= pkg.version %>.zip'
		}
	}
}
```

## Notes:
- All the changes are in index.js.  There is also a new file called latest-snapshot-metadata.xml  Other changes are just noise to differentiate my fork.
- I think these changes would be useful for most people, but I have not tested with any other artifact repositories besides a recent version of Nexus (I'm running 2.11.3-01 now, these changes were developed against the most recent version in Dec of 2014
- Let me know if you'd like me to provide any more information, or make further changes before accepting this pull request.

Thanks,
Andre V
