### PR TITLE
Added `uploadMethod` option to allow uploading via native NodeJS HTTP/S.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,6 +50,7 @@ module.exports = function (grunt) {
                     url: 'http://localhost:8081/nexus/content/repositories/snapshots',
                     artifact: 'test/fixtures/example.zip',
                     noproxy: 'localhost',
+                    uploadMethod: 'node',
                     cwd: '',
                     quiet: false,
                     insecure: true
@@ -59,7 +60,7 @@ module.exports = function (grunt) {
                 options: {
                     groupId: "grunt-nexus-deployer",
                     artifactId: "grunt-nexus-deployer",
-                    version: "1.2",
+                    version: "1.3",
                     packaging: 'zip',
                     auth: {
                         username: auth.username,
@@ -69,6 +70,7 @@ module.exports = function (grunt) {
                     url: 'http://localhost:8081/nexus/content/repositories/releases',
                     artifact: 'test/fixtures/example.zip',
                     noproxy: 'localhost',
+                    uploadMethod: 'node',
                     cwd: '',
                     quiet: true
                 }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ grunt.initConfig({
 		  url: 'http://localhost:9220/nexus/content/repositories/releases',
 		  artifact: 'build/grunt-nexus-deployer.zip',
 		  noproxy: 'localhost',
+          uploadMethod: 'node',
 		  cwd: ''
 		}
       }
@@ -121,6 +122,12 @@ Default value: `'127.0.0.1'`
 
 list of comma separated addresses to exclude for which proxy is not applicable. This is a must when running proxy and HTTP_PROXY environment value is set.
 
+#### options.uploadMethod
+Type: `String`
+Default value: `'node'`
+
+The method to use to upload the artifact: `'node'` or `'curl'`.
+
 #### options.cwd
 Type: `String`
 Default value: `''`
@@ -161,6 +168,7 @@ grunt.initConfig({
 		  url: 'http://localhost:8081/nexus/content/repositories/releases',
 		  artifact: 'build/grunt-nexus-deployer.zip',
 		  noproxy: 'localhost',
+          uploadMethod: 'node',
 		  cwd: ''
 		}
       }
@@ -187,6 +195,7 @@ grunt.initConfig({
 		  url: 'http://localhost:8081/nexus/content/repositories/snapshots',
 		  artifact: 'build/grunt-nexus-deployer.zip',
 		  noproxy: 'localhost',
+          uploadMethod: 'node',
 		  cwd: '',
 		  parallel:false,
 		  quiet: true


### PR DESCRIPTION
Added `uploadMethod` option to allow uploading via native NodeJS HTTP/S.  This will allow for those who do not have 'curl' installed on their device to use `grunt-nexus-deployer`.