### PR TITLE
lastUpdated is now populated with UTC time instead of local time

### DIFF
--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -157,6 +157,6 @@ module.exports = function (options, cb) {
         throw {name: "IllegalArgumentException", message: "upload artifact options required."};
     }
     exec = process.env.MOCK_NEXUS ? require('./mockexec') : require('child_process').exec;
-    options.lastUpdated = process.env.MOCK_NEXUS ? '11111111111111': dateformat(new Date(), "yyyymmddHHMMss");
+    options.lastUpdated = process.env.MOCK_NEXUS ? '11111111111111': dateformat(new Date(), "yyyymmddHHMMss", true);
     createAndUploadArtifacts(options, cb);
 };


### PR DESCRIPTION
lastUpdated in maven-metadata.xml is now populated with UTC time instead of local time.

Fixes #20 