### PR TITLE
fix asynchronous race problem that might occur when creating pomDir

### DIFF
--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -36,12 +36,24 @@ var save = function (fileContent, pomDir, fileName) {
     file.write(pomDir + '/' + fileName + '.sha1', sha1(fileContent));
 };
 
+var directoryExists = function(dir) {
+    try {
+        return fs.statSync(dir).isDirectory();
+    } catch (e) {
+        // error is thrown by statSync when path does not exist
+        if (e.code === 'ENOENT') {
+            return false
+        }
+        throw e;
+    }
+}
+
 var createAndUploadArtifacts = function (options, done) {
     var pomDir = options.pomDir || 'test/poms';
 
     options.parallel = options.parallel === undefined ? false : options.parallel;
-    if (!file.existsSync(pomDir)) {
-        file.mkdirSync(pomDir);
+    if (!directoryExists(pomDir)) {
+        fs.mkdirSync(pomDir);
     }
 
 

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -6,6 +6,7 @@ var ejs = require('ejs')
     , crypto = require('crypto')
     , async = require('async')
     , grunt = require('grunt')
+    , fs = require('fs')
     , file = grunt.file
     , log = grunt.log;
 
@@ -46,7 +47,7 @@ var directoryExists = function(dir) {
         }
         throw e;
     }
-}
+};
 
 var createAndUploadArtifacts = function (options, done) {
     var pomDir = options.pomDir || 'test/poms';

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -40,8 +40,8 @@ var createAndUploadArtifacts = function (options, done) {
     var pomDir = options.pomDir || 'test/poms';
 
     options.parallel = options.parallel === undefined ? false : options.parallel;
-    if (!file.exists(pomDir)) {
-        file.mkdir(pomDir);
+    if (!file.existsSync(pomDir)) {
+        file.mkdirSync(pomDir);
     }
 
 


### PR DESCRIPTION
`fs.exists(pomDir)` is an asynchronous call, it's not correct to expect a return value and use it as a condition to create the dir. I have some error with this. So I've changed to use the "sync" version of exists and mkdir instead