### PR TITLE
Handle passwords with special characters

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,7 @@
 module.exports = function (grunt) {
 
     // Project configuration.
-    var auth = {username: 'admin', password: 'admin123'};
+    var auth = {username: 'admin', password: 'baz(boo)\'M0o'};
     grunt.initConfig({
         auth: auth,
         jshint: {

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -70,7 +70,9 @@ var createAndUploadArtifacts = function (options, done) {
 
             if (options.auth) {
                 curlOptions.push('-u');
-                curlOptions.push(options.auth.username + ":" + options.auth.password);
+                var authString = options.auth.username + ':' + options.auth.password;
+                authString.replace(/'/g, '\\\'');
+                curlOptions.push("'" + authString + "'");
             }
 
             if (options.insecure) {

--- a/test/nexus_deployer_test.js
+++ b/test/nexus_deployer_test.js
@@ -40,6 +40,14 @@ describe('Nexus Deployer', function () {
             });
         });
 
+        it('handles passwords with special characters correctly', function () {
+            releaseHistory.concat(snapshotHistory).forEach(function (callParams) {
+                if (callParams) {
+                    callParams.should.match(/\-u 'admin\:baz\(boo\)\'M0o/);
+                }
+            });
+        });
+
         it('release uploads must not contain metadata files', function () {
             releaseHistory.filter(function (cmd) {
                 return INNER_METADATA_FILE_PATTERN.test(cmd);
@@ -67,19 +75,19 @@ describe('Nexus Deployer', function () {
                 }
             });
         });
-		
+
 		it('inner.xml should be generated correctly', function() {
 			var expected = fs.readFileSync('test/expected/inner.xml', 'utf8');
 			var actual = fs.readFileSync('test/pom/inner.xml', 'utf8');
 			actual.should.equal(expected);
 		});
-		
+
 		it('outer.xml should be generated correctly', function() {
 			var expected = fs.readFileSync('test/expected/outer.xml', 'utf8');
 			var actual = fs.readFileSync('test/pom/outer.xml', 'utf8');
 			actual.should.equal(expected);
 		});
-		
+
 		it('pom.xml should be generated correctly', function() {
 			var expected = fs.readFileSync('test/expected/pom.xml', 'utf8');
 			var actual = fs.readFileSync('test/pom/pom.xml', 'utf8');


### PR DESCRIPTION
`auth.username` and `auth.password` are used as command line parameters for curl. Since they are not quoted, special characters like e.g. brackets `(`, `)` or the dollar sign `$` (which nexus allows as characters in passwords) will be evaluated in the shell that the assembled curl command is passed to.

With this PR, the username:password combination passed to curl will be put into single quotes (single quotes in the password being escaped). 