### PR TITLE
Removing --output: '/dev/null' from the `curl` command parameter and …

### DIFF
--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -62,7 +62,8 @@ var createAndUploadArtifacts = function (options, done) {
 
             var curlOptions = [
                 '--silent',
-                '--output', '/dev/stderr',
+                '--fail',
+                '--show-error',
                 '--write-out', '"%{http_code}"',
                 '--upload-file', fileLocation,
                 '--noproxy', options.noproxy ? options.noproxy : '127.0.0.1'


### PR DESCRIPTION
Resolve the #18 issue, handling an error code with the correct flags  `--fail` and `--show-error`
This still mute all the output of the curl command and handle the message only in error case.