### PR TITLE
fix mkdir when parent directory does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "dependencies": {
         "dateformat":"1.0.11",
         "async": "0.9.0",
-        "ejs": "~2.3.1"
+        "ejs": "~2.3.1",
+        "mkdirp": "^0.5.1"
     },
     "devDependencies": {
         "grunt-contrib-jshint": "~0.8.0",

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -7,6 +7,7 @@ var ejs = require('ejs')
     , async = require('async')
     , grunt = require('grunt')
     , fs = require('fs')
+    , mkdirp = require('mkdirp')
     , file = grunt.file
     , log = grunt.log;
 
@@ -54,7 +55,7 @@ var createAndUploadArtifacts = function (options, done) {
 
     options.parallel = options.parallel === undefined ? false : options.parallel;
     if (!directoryExists(pomDir)) {
-        fs.mkdirSync(pomDir);
+        mkdirp(pomDir);
     }
 
 


### PR DESCRIPTION
Hi,

At our company our Jenkins builds started failing after we updated grunt-nexus-deployer from 0.0.4 to 0.1.0. _(Update: That, and some other changes. I realised later that it wasn't the upgrade of grunt-nexus-deployer on its own. Still, the fix remains valid.)_

It threw an error if any of the parent directories does not exist, e.g. "ENOENT: no such file or directory, mkdir 'build/pom'" if 'build' directory does not exist.

I added `mkdirp` to make it recursively add directories. After this fix our builds were successful again :).
