### PR TITLE
Handle status 202 as ok

### DIFF
--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -111,7 +111,7 @@ var createAndUploadArtifacts = function (options, done) {
                 status = data;
             });
             childProcess.on('close', function (code) {
-                if (code !== 0 || (status !== "200" && status !== "201")) {
+                if (code !== 0 || (status !== "200" && status !== "201" && status !== "202")) {
                     cb("Status code " + status + " for " + targetUri, null);
                 } else {
                     cb(null, "Ok");


### PR DESCRIPTION
Artifactory Maven Repository (JFrog) is returning status HTTP Status 202.
I need the grunt-nexus-deployer to handle this as on Ok case. 
Tested the change with Artifactory, all seems fine after acception 202 as good