### PR TITLE
Remove version tag from outer maven-metadata.xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,9 @@
         "grunt-contrib-clean": "^1.0.0",
         "grunt": "^1.0.1",
         "grunt-mocha-test": "^0.13.2",
-        "should":"^11.1.1",
-        "grunt-env":"^0.4.4"
+        "should": "^11.1.1",
+        "grunt-env": "^0.4.4",
+        "grunt-mocha": "^1.2.0"
     },
     "peerDependencies": {
         "grunt": ">=0.4.2"

--- a/tasks/template/project-metadata.xml
+++ b/tasks/template/project-metadata.xml
@@ -2,7 +2,6 @@
 <metadata>
     <groupId>{{ groupId }}</groupId>
     <artifactId>{{ artifactId }}</artifactId>
-    <version>{{ version }}</version>
     <versioning>
         <latest>{{ version }}</latest>
         <versions>

--- a/test/expected/outer.xml
+++ b/test/expected/outer.xml
@@ -2,7 +2,6 @@
 <metadata>
     <groupId>grunt-nexus-deployer</groupId>
     <artifactId>grunt-nexus-deployer</artifactId>
-    <version>1.2</version>
     <versioning>
         <latest>1.2</latest>
         <versions>


### PR DESCRIPTION
#### Background
In Sonatype Nexus Repository OSS 2.29.2-02, I started receiving 400 bad request errors when uploading an artifact using this grunt plugin.  Unfortunately, I do not track updates to the Sonatype instance and the artifact had not been built for several months so I cannot pinpoint the first version of Sonatype in which the issue began to occur in.

#### Changes and rationale
Upon further inspection, the curl command to upload the outer maven-metadata.xml file was the culprit. Removing the version tag in the outer maven-metadata.xml template resolves the 400 error. On comparison with another artifact uploaded using the standard Gradle publish plugin, there is no version tag nested below the metadata tag in the file it generates either. 

I only tested uploading to Sonatype Nexus 2.29.2-02 so there is a slim possibility that uploading to older versions or a different hosting repository could break with this change.